### PR TITLE
Bring back the term "content-agnostic"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ A curated list of awesome FSRS implementations, papers and resources. Feel free 
 
 - #### Anki (https://apps.ankiweb.net/)
 
-  Free and open source, highly customizable flashcard application for Windows, Mac, Linux, iPhone, and Android. Supports text, images, audio, videos, and scientific markup (via LaTex). Offers free synchronization service using AnkiWeb, with community-shared add-ons and decks.
+  Free and open source, content-agnostic flashcard application for Windows, Mac, Linux, iPhone, and Android. Supports text, images, audio, videos, and scientific markup (via LaTex). Offers free synchronization service using AnkiWeb, with community-shared add-ons and decks.
 
   - FSRS available as an opt-in feature replacing the default SM-2 algorithm.
   - Additionally, this [add-on](https://ankiweb.net/shared/info/759844606) offers a variety of extra features, such as Postpone, Advance, Load Balancing and Easy Days.
-
 
 ### Note-taking
 


### PR DESCRIPTION
"Content-agnostic" refers to the design of Anki being a content-free flashcard application allowing user to choose whatever deck they please and allowing them to create their own deck. Contrast to other flashcard applications like Wanikani where users of the application learn the same set of cards without any options to use the application for another purpose besides what it originally offered for.

The previous change to "highly customizable" lost this meaning.

Discussion: https://github.com/open-spaced-repetition/awesome-fsrs/commit/1d7bace84c449efb65bb34821e019bfe04515186#r146399797