### PR TITLE
Add KaChiKa to Specialized Flashcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ Intended for language learning, HSRS continuously refreshes card content using a
 
 Used to power [grsly](https://grsly.com/), a tool for learning Japanese grammar.
 
+#### [KaChiKa](https://kachika.app/)
+
+  KaChiKa is an AI-powered photo-to-flashcard app for language learners. Snap a photo of any object — a coffee cup, a cat, a street sign — and KaChiKa extracts the vocabulary, generates real-world example sentences, and schedules reviews using FSRS.
+
+  Supports English, Japanese, French, Korean, Italian, Spanish, and Chinese. All photos are stored locally on device for privacy. Available on iOS, Android, and APK.
+
 #### [LeetFlash](https://leetflash.com/)
 
   LeetFlash is a flashcard review app for review LeetCode algorithm questions. It leverages TS-FSRS for scheduling flashcards.


### PR DESCRIPTION
## Summary

Adds [KaChiKa](https://kachika.app/) to the **Specialized Flashcard** section, between HSRS and LeetFlash (alphabetical order).

KaChiKa is an AI-powered photo-to-flashcard app for language learners. It uses FSRS to schedule reviews of vocabulary extracted from user photos, generating real-world example sentences for each captured word.

## Why FSRS Specialized Flashcard

- **FSRS-based scheduling**: KaChiKa adopts FSRS (over SM-2) for review timing, treating vocabulary retention as a stability-driven forgetting curve.
- **Specialized for vocabulary**: Unlike general flashcard apps (Anki, Mochi, Quanta), KaChiKa is built specifically for language vocabulary in real-life context — closest to AI Japanese Tutor and Rhythm Word in this section.
- **Multi-language**: English, Japanese, French, Korean, Italian, Spanish, Chinese (7 languages).
- **Privacy-first**: All images are processed and stored on-device, no upload.

## Entry placement

Placed between HSRS and LeetFlash to maintain alphabetical order within Specialized Flashcard.

## Checklist
- [x] Entry uses the same H4-header + paragraph format as neighboring entries
- [x] Description is factual; no marketing fluff
- [x] Tool is publicly available (iOS / Android / APK) and actively maintained
- [x] FSRS usage is real — KaChiKa schedules vocabulary reviews via FSRS forgetting curve