### PR TITLE
Add Avorio (macOS/iOS, FSRS-5 default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ A curated list of awesome FSRS implementations, papers and resources. Feel free 
 - FSRS available as an opt-in feature replacing the default SM-2 algorithm.
 - Additionally, this [add-on](https://ankiweb.net/shared/info/759844606) offers a variety of extra features, such as Postpone, Advance, Load Balancing and Easy Days.
 
+#### [Avorio](https://avorio.ai/)
+
+  Avorio is a native flashcard app for macOS and iPhone built around FSRS-5. It imports Anki `.apkg` and `.colpkg` files with scheduling state, review history, media, tags, note types, cloze deletions and image occlusion cards intact, so decks resume on the schedule they were already on instead of resetting to new, and exports back to `.apkg`. Cards live in a local SQLite database and the review path makes no network calls, so it works offline and does not require an account. The flashcard app, FSRS-5, Anki import/export, local AI via Ollama, and offline mode are free; optional subscriptions add cloud AI generation and Mac-to-iPhone sync.
+
+- FSRS-5 is the default scheduler. SM-2 is available per deck, and switching between them does not reset progress.
+- On import, Avorio can fit FSRS parameters to your own Anki review log rather than using generic defaults.
+- Avorio uses its own FSRS-5 implementation in a shared Rust core, exposed to SwiftUI through [UniFFI](https://github.com/mozilla/uniffi-rs).
+
 #### [Discito](https://discito.app)
 
   Discito is a native iOS flashcard app built around FSRS-6, with iCloud sync, on-device AI card generation, lecture-audio-to-flashcards, image occlusion authoring, and full-fidelity `.apkg` import/export. One-time purchase, no subscription.


### PR DESCRIPTION
I build Avorio, so this is a self-suggestion rather than a third-party recommendation. Opening it because you said a PR was welcome in #60.

Adds Avorio to **General Flashcard**, alphabetically between Anki and Discito.

Avorio is a native macOS and iOS flashcard app that defaults to FSRS-5. SM-2 is available per deck and switching between the two does not reset progress, and on import it can fit FSRS parameters to your actual Anki review log rather than using generic defaults.

Two things I tried to be careful about, since they are easy to get wrong in a list like this:

- **Implementation.** Avorio does not depend on `fsrs-rs`, `py-fsrs` or `ts-fsrs`; the scheduler is a first-party Rust implementation in the shared core. The entry says "its own FSRS-5 implementation" rather than naming one of your libraries, so nobody reads it as a downstream user of them.
- **No parity claim.** Other entries state that their port was validated against a reference implementation. Avorio has no reference-vector tests against `py-fsrs`, so I left that out rather than implying it.

Also deliberately absent: Android, which is in development and not shipped, and anything about the Mac App Store, since macOS ships only as a direct download.

Happy to trim the entry, drop the bullets, or reword anything that does not match how you want the list to read.
